### PR TITLE
File inspector cleanup (LEAN-1309)

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -50,19 +50,7 @@ import {
   namesWithDesignationMap,
 } from './util'
 
-/**
- * This is the main component of the file handling
- * that should be called in the inspector,
- * and it expects to receive an array of submission attachments
- * and use Drag-and-Drop technique for manuscript-frontend inspector.
- *
- * File section component consist of three types of files which is:
- * 1- Inline files.
- * 2- Supplemental files.
- * 3- Other files.
- */
-
-export interface Attachments {
+export interface FileManagement {
   getAttachments: () => SubmissionAttachment[]
   upload: (
     file: File,
@@ -81,10 +69,22 @@ export interface Attachments {
   ) => Promise<boolean>
 }
 
+/**
+ * This is the main component of the file handling
+ * that should be called in the inspector,
+ * and it expects to receive an array of submission attachments
+ * and use Drag-and-Drop technique for manuscript-frontend inspector.
+ *
+ * File section component consist of three types of files which is:
+ * 1- Inline files.
+ * 2- Supplemental files.
+ * 3- Other files.
+ */
+
 export const PermissionsContext = createContext<null | Capabilities>(null)
 
 export const FileManager: React.FC<{
-  attachment: Attachments
+  attachment: FileManagement
   modelMap: Map<string, Model>
   saveModel: (model: Build<Supplement>) => Promise<Build<Supplement>>
   enableDragAndDrop: boolean

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -50,23 +50,29 @@ import {
   namesWithDesignationMap,
 } from './util'
 
+export type Upload = (
+  file: File,
+  designation: string
+) => Promise<boolean | SubmissionAttachment | undefined>
+
+export type Replace = (
+  attachmentId: string,
+  name: string,
+  file: File,
+  typeId: string
+) => Promise<boolean | SubmissionAttachment | undefined>
+
+export type ChangeDesignation = (
+  attachmentId: string,
+  typeId: string,
+  name: string
+) => Promise<boolean>
+
 export interface FileManagement {
   getAttachments: () => SubmissionAttachment[]
-  upload: (
-    file: File,
-    designation: string
-  ) => Promise<boolean | SubmissionAttachment | undefined>
-  replace: (
-    attachmentId: string,
-    name: string,
-    file: File,
-    typeId: string
-  ) => Promise<boolean | SubmissionAttachment | undefined>
-  changeDesignation: (
-    attachmentId: string,
-    typeId: string,
-    name: string
-  ) => Promise<boolean>
+  upload: Upload
+  replace: Replace
+  changeDesignation: ChangeDesignation
 }
 
 /**

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -84,7 +84,7 @@ export interface FileManagement {
 export const PermissionsContext = createContext<null | Capabilities>(null)
 
 export const FileManager: React.FC<{
-  attachment: FileManagement
+  fileManagement: FileManagement
   modelMap: Map<string, Model>
   saveModel: (model: Build<Supplement>) => Promise<Build<Supplement>>
   enableDragAndDrop: boolean
@@ -94,7 +94,7 @@ export const FileManager: React.FC<{
   saveModel,
   enableDragAndDrop,
   can,
-  attachment: { getAttachments, changeDesignation, replace, upload },
+  fileManagement: { getAttachments, changeDesignation, replace, upload },
 }) => {
   const [state, dispatch] = useReducer(reducer, getInitialState())
   const handleReplaceFile = useCallback(

--- a/src/components/FileManager/FileSectionItem/DesignationActions.tsx
+++ b/src/components/FileManager/FileSectionItem/DesignationActions.tsx
@@ -20,6 +20,7 @@ import styled from 'styled-components'
 import { Capabilities } from '../../../lib/capabilities'
 import BottomArrowIcon from '../../icons/BottomArrowIcon'
 import { ConfirmationPopUp } from '../ConfirmationPopUp'
+import { ChangeDesignation } from '../FileManager'
 import { Action } from '../FileSectionState'
 import { TooltipDiv } from '../TooltipDiv'
 import {
@@ -36,11 +37,7 @@ export const DesignationActions: React.FC<{
   designation?: Designation
   attachmentId: string
   fileExtension?: string
-  handleChangeDesignation?: (
-    attachmentId: string,
-    typeId: string,
-    name: string
-  ) => Promise<boolean>
+  handleChangeDesignation?: ChangeDesignation
   fileName: string
   can: Capabilities | null
   dispatch?: Dispatch<Action>

--- a/src/components/FileManager/FileSectionItem/DesignationActions.tsx
+++ b/src/components/FileManager/FileSectionItem/DesignationActions.tsx
@@ -37,12 +37,10 @@ export const DesignationActions: React.FC<{
   attachmentId: string
   fileExtension?: string
   handleChangeDesignation?: (
-    submissionId: string,
     attachmentId: string,
     typeId: string,
     name: string
   ) => Promise<boolean>
-  submissionId: string
   fileName: string
   can: Capabilities | null
   dispatch?: Dispatch<Action>
@@ -51,7 +49,6 @@ export const DesignationActions: React.FC<{
   attachmentId,
   fileExtension,
   handleChangeDesignation,
-  submissionId,
   fileName,
   can,
   dispatch,
@@ -97,7 +94,6 @@ export const DesignationActions: React.FC<{
     const handleMoveAction = () => {
       handleChangeDesignation &&
         handleChangeDesignation(
-          submissionId,
           attachmentId,
           confirmationPopUpData.selectedDesignation,
           fileName
@@ -141,7 +137,6 @@ export const DesignationActions: React.FC<{
               <DesignationActionsList
                 handleChangeDesignation={handleChangeDesignation}
                 designationActionsList={designationActionsList}
-                submissionId={submissionId}
                 fileName={fileName}
                 designation={designation}
                 attachmentId={attachmentId}

--- a/src/components/FileManager/FileSectionItem/DesignationActionsList.tsx
+++ b/src/components/FileManager/FileSectionItem/DesignationActionsList.tsx
@@ -32,13 +32,11 @@ import {
 
 export const DesignationActionsList: React.FC<{
   handleChangeDesignation?: (
-    submissionId: string,
     attachmentId: string,
     typeId: string,
     name: string
   ) => Promise<boolean>
   designationActionsList: Array<Designation>
-  submissionId: string
   fileName: string
   designation?: Designation
   attachmentId: string
@@ -51,7 +49,6 @@ export const DesignationActionsList: React.FC<{
 }> = ({
   handleChangeDesignation,
   designationActionsList,
-  submissionId,
   fileName,
   designation,
   attachmentId,
@@ -69,7 +66,6 @@ export const DesignationActionsList: React.FC<{
       if (dispatch) {
         dispatch(
           actions.MOVE_FILE(
-            submissionId,
             attachmentId,
             getDesignationName(designation),
             fileName,
@@ -85,7 +81,6 @@ export const DesignationActionsList: React.FC<{
     } else {
       handleChangeDesignation &&
         handleChangeDesignation(
-          submissionId,
           attachmentId,
           getDesignationName(designation),
           fileName

--- a/src/components/FileManager/FileSectionItem/DesignationActionsList.tsx
+++ b/src/components/FileManager/FileSectionItem/DesignationActionsList.tsx
@@ -15,6 +15,7 @@
  */
 import React, { Dispatch } from 'react'
 
+import { ChangeDesignation } from '../FileManager'
 import { Action, actions } from '../FileSectionState'
 import {
   ActionsBox,
@@ -31,11 +32,7 @@ import {
 } from '../util'
 
 export const DesignationActionsList: React.FC<{
-  handleChangeDesignation?: (
-    attachmentId: string,
-    typeId: string,
-    name: string
-  ) => Promise<boolean>
+  handleChangeDesignation?: ChangeDesignation
   designationActionsList: Array<Designation>
   fileName: string
   designation?: Designation

--- a/src/components/FileManager/FileSectionItem/FileInfo.tsx
+++ b/src/components/FileManager/FileSectionItem/FileInfo.tsx
@@ -30,12 +30,10 @@ export const FileInfo: React.FC<{
   designation?: Designation
   attachmentId: string
   handleChangeDesignation: (
-    submissionId: string,
     attachmentId: string,
     typeId: string,
     name: string
   ) => Promise<boolean>
-  submissionId?: string
   dispatch?: Dispatch<Action>
 }> = ({
   showAttachmentName,
@@ -46,7 +44,6 @@ export const FileInfo: React.FC<{
   designation,
   attachmentId,
   handleChangeDesignation,
-  submissionId,
   dispatch,
 }) => {
   const fileName = submissionAttachmentName.substring(
@@ -58,13 +55,12 @@ export const FileInfo: React.FC<{
 
   return (
     <FileInfoContainer>
-      {showDesignationActions && designation !== undefined && submissionId && (
+      {showDesignationActions && designation !== undefined && (
         <DesignationActions
           designation={designation}
           attachmentId={attachmentId}
           fileExtension={fileExtension}
           handleChangeDesignation={handleChangeDesignation}
-          submissionId={submissionId}
           fileName={submissionAttachmentName}
           dispatch={dispatch}
           can={can}

--- a/src/components/FileManager/FileSectionItem/FileInfo.tsx
+++ b/src/components/FileManager/FileSectionItem/FileInfo.tsx
@@ -16,7 +16,7 @@
 import React, { Dispatch, useContext } from 'react'
 import styled from 'styled-components'
 
-import { PermissionsContext } from '../FileManager'
+import { ChangeDesignation, PermissionsContext } from '../FileManager'
 import { Action } from '../FileSectionState'
 import { Designation } from '../util'
 import { DesignationActions } from './DesignationActions'
@@ -29,11 +29,7 @@ export const FileInfo: React.FC<{
   fileExtension: string
   designation?: Designation
   attachmentId: string
-  handleChangeDesignation: (
-    attachmentId: string,
-    typeId: string,
-    name: string
-  ) => Promise<boolean>
+  handleChangeDesignation: ChangeDesignation
   dispatch?: Dispatch<Action>
 }> = ({
   showAttachmentName,

--- a/src/components/FileManager/FileSectionItem/FileSectionItem.tsx
+++ b/src/components/FileManager/FileSectionItem/FileSectionItem.tsx
@@ -46,7 +46,6 @@ export type SubmissionAttachmentType = {
 }
 
 export interface FileSectionItemProps {
-  submissionId?: string
   externalFile: SubmissionAttachment
   title: string
   showAttachmentName?: boolean
@@ -54,14 +53,12 @@ export interface FileSectionItemProps {
   showActions?: boolean
   handleDownload?: (url: string) => void
   handleReplace?: (
-    submissionId: string,
     attachmentId: string,
     name: string,
     file: File,
     typeId: string
-  ) => Promise<{ data: { uploadAttachment: SubmissionAttachment } }>
+  ) => Promise<boolean | SubmissionAttachment | undefined>
   handleChangeDesignation: (
-    submissionId: string,
     attachmentId: string,
     typeId: string,
     name: string
@@ -75,7 +72,6 @@ export interface FileSectionItemProps {
 }
 
 export const FileSectionItem: React.FC<FileSectionItemProps> = ({
-  submissionId,
   externalFile,
   title,
   showAttachmentName = false,
@@ -124,7 +120,6 @@ export const FileSectionItem: React.FC<FileSectionItemProps> = ({
           designation={designation}
           attachmentId={externalFile.id}
           handleChangeDesignation={handleChangeDesignation}
-          submissionId={submissionId}
           dispatch={dispatch}
         />
       </ItemContainer>
@@ -138,7 +133,7 @@ export const FileSectionItem: React.FC<FileSectionItemProps> = ({
           <CloseOIcon color={'#6E6E6E'} />
         </IconCloseButton>
       )}
-      {handleDownload && handleReplace && submissionId && (
+      {handleDownload && handleReplace && (
         <DropdownContainer ref={wrapperRef}>
           <ActionsIcon
             onClick={toggleOpen}
@@ -152,7 +147,6 @@ export const FileSectionItem: React.FC<FileSectionItemProps> = ({
             <ItemActions
               replaceAttachmentHandler={handleReplace}
               downloadAttachmentHandler={handleDownload}
-              submissionId={submissionId}
               attachmentId={externalFile.id}
               fileName={externalFile.name}
               designation={externalFile.type.label}
@@ -212,7 +206,7 @@ export const Item = styled.div`
   ${DropdownContainer} {
     position: absolute;
     top: 24px;
-    right: 0px;
+    right: 0;
     margin-right: 8px;
   }
 `

--- a/src/components/FileManager/FileSectionItem/FileSectionItem.tsx
+++ b/src/components/FileManager/FileSectionItem/FileSectionItem.tsx
@@ -22,6 +22,7 @@ import { DropdownContainer } from '../../Dropdown'
 import { CloseOIcon } from '../../icons/'
 import DotsIcon from '../../icons/dots-icon'
 import { Maybe } from '../../SubmissionInspector/types'
+import { ChangeDesignation, FileManagement, Replace } from '../FileManager'
 import { Action } from '../FileSectionState'
 import { Designation, namesWithDesignationMap } from '../util'
 import { FileInfo } from './FileInfo'
@@ -52,17 +53,8 @@ export interface FileSectionItemProps {
   showDesignationActions?: boolean
   showActions?: boolean
   handleDownload?: (url: string) => void
-  handleReplace?: (
-    attachmentId: string,
-    name: string,
-    file: File,
-    typeId: string
-  ) => Promise<boolean | SubmissionAttachment | undefined>
-  handleChangeDesignation: (
-    attachmentId: string,
-    typeId: string,
-    name: string
-  ) => Promise<boolean>
+  handleReplace?: Replace
+  handleChangeDesignation: ChangeDesignation
   dispatch?: Dispatch<Action>
   dragRef?: DragElementWrapper<DragSourceOptions>
   className?: string

--- a/src/components/FileManager/FileSectionItem/FileSectionUploadItem.tsx
+++ b/src/components/FileManager/FileSectionItem/FileSectionUploadItem.tsx
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { CSSProperties, useState } from 'react'
+import React, { CSSProperties } from 'react'
 import { DragElementWrapper, DragSourceOptions } from 'react-dnd'
 import styled from 'styled-components'
 
-import { DesignationActions } from './DesignationActions'
 import { FileInfoContainer, FileName, FileNameContainer } from './FileInfo'
-import { ActionsIcon, Item, ItemContainer } from './FileSectionItem'
+import { Item, ItemContainer } from './FileSectionItem'
 import { FileTypeIcon } from './FileTypeIcon'
 import { ProgressBarUploadItem } from './ProgressBarUploadItem'
 
 export interface FileSectionItemProps {
   fileName: string
   isLoading: boolean
-  submissionId: string
   dragRef?: DragElementWrapper<DragSourceOptions>
   className?: string
   style?: CSSProperties
@@ -38,7 +36,6 @@ export interface FileSectionItemProps {
 export const FileSectionUploadItem: React.FC<FileSectionItemProps> = ({
   fileName,
   isLoading,
-  submissionId,
   dragRef,
   className,
   style,
@@ -68,7 +65,7 @@ export const UploadItemContainer = styled(ItemContainer)`
 export const ProgressBar = styled.div`
   background: #1a9bc7;
   opacity: 0.7;
-  border-radius: 8px 0px 0px 8px;
+  border-radius: 8px 0 0 8px;
   width: 20%;
   height: 100%;
 `

--- a/src/components/FileManager/FileSectionItem/ItemActions.tsx
+++ b/src/components/FileManager/FileSectionItem/ItemActions.tsx
@@ -35,14 +35,12 @@ import { SubmissionAttachment } from './FileSectionItem'
 export const ItemActions: React.FC<{
   downloadAttachmentHandler: (url: string) => void
   replaceAttachmentHandler: (
-    submissionId: string,
     attachmentId: string,
     name: string,
     file: File,
     typeId: string
-  ) => Promise<{ data: { uploadAttachment: SubmissionAttachment } }>
+  ) => Promise<boolean | SubmissionAttachment | undefined>
   handleUpdateInline?: (attachment: SubmissionAttachment) => void
-  submissionId: string
   attachmentId: string
   fileName: string
   designation?: Maybe<string> | undefined
@@ -54,7 +52,6 @@ export const ItemActions: React.FC<{
   downloadAttachmentHandler,
   replaceAttachmentHandler,
   handleUpdateInline,
-  submissionId,
   attachmentId,
   fileName,
   designation,
@@ -92,16 +89,14 @@ export const ItemActions: React.FC<{
         )
       }
       const result = await replaceAttachmentHandler(
-        submissionId,
         attachmentId,
         fileName,
         file,
         attachmentDesignation
       )
 
-      const { uploadAttachment } = result?.data
-      if (uploadAttachment && handleUpdateInline) {
-        handleUpdateInline(uploadAttachment)
+      if (!(result instanceof Boolean) && handleUpdateInline) {
+        handleUpdateInline(result as SubmissionAttachment)
       }
 
       if (dispatch) {

--- a/src/components/FileManager/FileSectionItem/ItemActions.tsx
+++ b/src/components/FileManager/FileSectionItem/ItemActions.tsx
@@ -23,7 +23,7 @@ import React, {
 
 import { DropdownList } from '../../Dropdown'
 import { Maybe } from '../../SubmissionInspector/types'
-import { PermissionsContext } from '../FileManager'
+import { PermissionsContext, Replace } from '../FileManager'
 import { Action, actions } from '../FileSectionState'
 import { ActionsItem } from '../ItemsAction'
 import { Designation, namesWithDesignationMap } from '../util'
@@ -34,12 +34,7 @@ import { SubmissionAttachment } from './FileSectionItem'
  */
 export const ItemActions: React.FC<{
   downloadAttachmentHandler: (url: string) => void
-  replaceAttachmentHandler: (
-    attachmentId: string,
-    name: string,
-    file: File,
-    typeId: string
-  ) => Promise<boolean | SubmissionAttachment | undefined>
+  replaceAttachmentHandler: Replace
   handleUpdateInline?: (attachment: SubmissionAttachment) => void
   attachmentId: string
   fileName: string

--- a/src/components/FileManager/FileSectionItem/ItemActions.tsx
+++ b/src/components/FileManager/FileSectionItem/ItemActions.tsx
@@ -95,8 +95,8 @@ export const ItemActions: React.FC<{
         attachmentDesignation
       )
 
-      if (!(result instanceof Boolean) && handleUpdateInline) {
-        handleUpdateInline(result as SubmissionAttachment)
+      if (typeof result === 'object' && handleUpdateInline) {
+        handleUpdateInline(result)
       }
 
       if (dispatch) {

--- a/src/components/FileManager/FileSectionState.tsx
+++ b/src/components/FileManager/FileSectionState.tsx
@@ -30,9 +30,7 @@ export const getInitialState = (): State => ({
 export interface State {
   uploadedFile: File | undefined
   isUploadFile: boolean
-  moveToOtherState:
-    | { submissionId: string; typeId: string; name: string }
-    | undefined
+  moveToOtherState: { typeId: string; name: string } | undefined
   successMessage: string
   isShowSuccessMessage: boolean
   selectDesignation: Designation | undefined
@@ -64,7 +62,6 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         moveToOtherState: {
-          submissionId: action.submissionId,
           typeId: action.typeId,
           name: action.name,
         },
@@ -132,14 +129,12 @@ export const actions = {
     designation,
   }),
   MOVE_FILE: (
-    submissionId: string,
     attachmentId: string,
     typeId: string,
     name: string,
     successMoveMessage: string
   ): Action => ({
     type: ActionTypes.MOVE_FILE,
-    submissionId,
     typeId,
     name,
     successMoveMessage,

--- a/src/components/FileManager/FilesSection.tsx
+++ b/src/components/FileManager/FilesSection.tsx
@@ -27,10 +27,8 @@ import { FileSectionType, getDesignationName } from './util'
  *  This component represents the other files in the file section.
  */
 export const FilesSection: React.FC<{
-  submissionId: string
   enableDragAndDrop: boolean
   handleUpload: (
-    submissionId: string,
     file: File,
     designation: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +38,6 @@ export const FilesSection: React.FC<{
   dispatch: Dispatch<Action>
   state: State
 }> = ({
-  submissionId,
   enableDragAndDrop,
   handleUpload,
   fileSection,
@@ -62,7 +59,6 @@ export const FilesSection: React.FC<{
     state.uploadedFile &&
       state.selectDesignation !== undefined &&
       handleUpload(
-        submissionId,
         state.uploadedFile,
         getDesignationName(state.selectDesignation)
       )
@@ -77,7 +73,6 @@ export const FilesSection: React.FC<{
             <UploadFileArea
               handleUploadFile={handleUpload}
               fileSection={fileSection}
-              submissionId={submissionId}
               dispatch={dispatch}
             />
           )}
@@ -85,7 +80,6 @@ export const FilesSection: React.FC<{
             state.uploadedFile &&
             state.selectDesignation !== undefined && (
               <FileSectionUploadItem
-                submissionId={submissionId}
                 fileName={state.uploadedFile.name}
                 isLoading={state.isUploadFile}
               />

--- a/src/components/FileManager/FilesSection.tsx
+++ b/src/components/FileManager/FilesSection.tsx
@@ -16,7 +16,7 @@
 import React, { Dispatch, useContext } from 'react'
 
 import { DragItemArea } from './DragItemArea'
-import { PermissionsContext } from './FileManager'
+import { PermissionsContext, Upload } from './FileManager'
 import { FileSectionUploadItem } from './FileSectionItem/FileSectionUploadItem'
 import { Action, actions, State } from './FileSectionState'
 import { SelectDialogDesignation } from './SelectDialogDesignation'
@@ -28,11 +28,7 @@ import { FileSectionType, getDesignationName } from './util'
  */
 export const FilesSection: React.FC<{
   enableDragAndDrop: boolean
-  handleUpload: (
-    file: File,
-    designation: string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Promise<any>
+  handleUpload: Upload
   fileSection: FileSectionType
   filesItem: JSX.Element[]
   dispatch: Dispatch<Action>

--- a/src/components/FileManager/InlineFilesSection.tsx
+++ b/src/components/FileManager/InlineFilesSection.tsx
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Model } from '@manuscripts/manuscripts-json-schema'
-import React, { Dispatch, useCallback, useMemo } from 'react'
+import React, { Dispatch, useCallback } from 'react'
 import styled from 'styled-components'
 
 import { useDropdown } from '../../hooks/use-dropdown'
-import getInlineFiles from '../../lib/inlineFiles'
 import DotsIcon from '../icons/dots-icon'
 import {
-  FileDescription,
   FileInfoContainer,
   FileNameTitleContainer,
   FileTitle,
@@ -46,7 +43,6 @@ export interface ExternalFileRef {
 }
 
 export const InlineFilesSection: React.FC<{
-  submissionId: string
   inlineFiles: {
     id: string
     label: string
@@ -55,12 +51,11 @@ export const InlineFilesSection: React.FC<{
     attachments?: SubmissionAttachment[]
   }[]
   handleReplace: (
-    submissionId: string,
     attachmentId: string,
     name: string,
     file: File,
     typeId: string
-  ) => Promise<{ data: { uploadAttachment: SubmissionAttachment } }>
+  ) => Promise<boolean | SubmissionAttachment | undefined>
   handleDownload: (url: string) => void
   handleUpdateInline?: (
     modelId: string,
@@ -69,7 +64,6 @@ export const InlineFilesSection: React.FC<{
   isEditor: boolean
   dispatch: Dispatch<Action>
 }> = ({
-  submissionId,
   handleReplace,
   handleDownload,
   handleUpdateInline,
@@ -107,7 +101,6 @@ export const InlineFilesSection: React.FC<{
               <FileReference
                 key={attachment.id}
                 attachment={attachment}
-                submissionId={submissionId}
                 handleReplace={handleReplace}
                 handleUpdateInline={handleUpdateInline}
                 handleDownload={handleDownload}
@@ -131,14 +124,12 @@ export const InlineFilesSection: React.FC<{
 
 const FileReference: React.FC<{
   attachment?: SubmissionAttachment & { modelId?: string }
-  submissionId: string
   handleReplace: (
-    submissionId: string,
     attachmentId: string,
     name: string,
     file: File,
     typeId: string
-  ) => Promise<{ data: { uploadAttachment: SubmissionAttachment } }>
+  ) => Promise<boolean | SubmissionAttachment | undefined>
   handleDownload: (url: string) => void
   handleUpdateInline?: (
     modelId: string,
@@ -147,7 +138,6 @@ const FileReference: React.FC<{
   dispatch: Dispatch<Action>
 }> = ({
   attachment,
-  submissionId,
   handleReplace,
   handleDownload,
   handleUpdateInline,
@@ -171,7 +161,7 @@ const FileReference: React.FC<{
         )}
         <FileReferenceName>{attachment.name}</FileReferenceName>
       </Container>
-      {handleDownload && handleReplace && submissionId && (
+      {handleDownload && handleReplace && (
         <DropdownContainer ref={wrapperRef}>
           <ActionsIcon
             onClick={toggleOpen}
@@ -191,7 +181,6 @@ const FileReference: React.FC<{
                 handleUpdateInline(attachment.modelId, uploadAttachment)
               }
               downloadAttachmentHandler={handleDownload}
-              submissionId={submissionId}
               attachmentId={attachment.id}
               fileName={attachment.name}
               designation={attachment.type.label}

--- a/src/components/FileManager/InlineFilesSection.tsx
+++ b/src/components/FileManager/InlineFilesSection.tsx
@@ -18,6 +18,7 @@ import styled from 'styled-components'
 
 import { useDropdown } from '../../hooks/use-dropdown'
 import DotsIcon from '../icons/dots-icon'
+import { Replace } from './FileManager'
 import {
   FileInfoContainer,
   FileNameTitleContainer,
@@ -50,12 +51,7 @@ export const InlineFilesSection: React.FC<{
     caption?: string
     attachments?: SubmissionAttachment[]
   }[]
-  handleReplace: (
-    attachmentId: string,
-    name: string,
-    file: File,
-    typeId: string
-  ) => Promise<boolean | SubmissionAttachment | undefined>
+  handleReplace: Replace
   handleDownload: (url: string) => void
   handleUpdateInline?: (
     modelId: string,

--- a/src/components/FileManager/UploadFileArea.tsx
+++ b/src/components/FileManager/UploadFileArea.tsx
@@ -24,6 +24,7 @@ import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import styled, { css } from 'styled-components'
 
+import { Upload } from './FileManager'
 import { Action, actions } from './FileSectionState'
 import { Designation, FileSectionType, getDesignationName } from './util'
 
@@ -31,11 +32,7 @@ import { Designation, FileSectionType, getDesignationName } from './util'
  * This component will show the drag or upload file area
  */
 export const UploadFileArea: React.FC<{
-  handleUploadFile: (
-    file: File,
-    designation: string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => Promise<any>
+  handleUploadFile: Upload
   fileSection: FileSectionType
   dispatch: Dispatch<Action>
 }> = ({ handleUploadFile, fileSection, dispatch }) => {

--- a/src/components/FileManager/UploadFileArea.tsx
+++ b/src/components/FileManager/UploadFileArea.tsx
@@ -24,7 +24,6 @@ import { DropTargetMonitor, useDrop } from 'react-dnd'
 import { NativeTypes } from 'react-dnd-html5-backend'
 import styled, { css } from 'styled-components'
 
-import { SubmissionAttachment } from './FileSectionItem/FileSectionItem'
 import { Action, actions } from './FileSectionState'
 import { Designation, FileSectionType, getDesignationName } from './util'
 
@@ -33,15 +32,13 @@ import { Designation, FileSectionType, getDesignationName } from './util'
  */
 export const UploadFileArea: React.FC<{
   handleUploadFile: (
-    submissionId: string,
     file: File,
     designation: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => Promise<any>
   fileSection: FileSectionType
-  submissionId: string
   dispatch: Dispatch<Action>
-}> = ({ handleUploadFile, fileSection, submissionId, dispatch }) => {
+}> = ({ handleUploadFile, fileSection, dispatch }) => {
   const [selectedFile, setSelectedFile] = useState<File>()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const isSupplementFilesTab = fileSection === FileSectionType.Supplements
@@ -57,11 +54,7 @@ export const UploadFileArea: React.FC<{
       setSelectedFile(file)
       dispatch(actions.UPLOAD_FILE(file))
       if (file && isSupplementFilesTab) {
-        handleUploadFile(
-          submissionId,
-          file,
-          getDesignationName(Designation.Supplementary)
-        )
+        handleUploadFile(file, getDesignationName(Designation.Supplementary))
       }
     }
   }
@@ -74,20 +67,13 @@ export const UploadFileArea: React.FC<{
         dispatch(actions.UPLOAD_FILE(file))
         if (selectedFile && isSupplementFilesTab) {
           handleUploadFile(
-            submissionId,
             selectedFile,
             getDesignationName(Designation.Supplementary)
           )
         }
       }
     },
-    [
-      dispatch,
-      handleUploadFile,
-      isSupplementFilesTab,
-      selectedFile,
-      submissionId,
-    ]
+    [dispatch, handleUploadFile, isSupplementFilesTab, selectedFile]
   )
 
   const [{ canDrop, isOver }, dropRef] = useDrop({

--- a/stories/FileManager.stories.tsx
+++ b/stories/FileManager.stories.tsx
@@ -82,7 +82,7 @@ storiesOf('FileManager', module).add('FileManager', () => {
     <BrowserRouter>
       <FileManager
         can={capabilities}
-        attachment={{
+        fileManagement={{
           getAttachments: () => attachments,
           upload,
           replace,

--- a/stories/FileManager.stories.tsx
+++ b/stories/FileManager.stories.tsx
@@ -22,42 +22,32 @@ import { attachments } from './data/attachments'
 const sleep = (milliseconds: number) => {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
-const handleUpload = async (
-  submissionId: string,
+const upload = async (
   file: File,
   designation: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> => {
   await sleep(5000) //test the upload file item in storybook
-  console.log('submissionId --> ' + submissionId)
   console.log('file --> ' + file.name)
   console.log('designation --> ' + designation)
   return true
 }
 
-const handleDownload = (url: string): void => {
-  console.log('url --> ' + url)
-}
-
-const handleReplace = async (
-  submissionId: string,
+const replace = async (
   attachmentId: string,
   name: string,
   file: File
 ): Promise<boolean> => {
-  console.log('submissionId --> ' + submissionId)
   console.log('file --> ' + file.name)
   console.log('name --> ' + name)
   return true
 }
 
-const handleChangeDesignation = async (
-  submissionId: string,
+const changeDesignation = async (
   attachmentId: string,
   designation: string | undefined,
   name: string
 ): Promise<boolean> => {
-  console.log('submissionId --> ' + submissionId)
   console.log('name --> ' + name)
   console.log('designation --> ' + designation)
   return true
@@ -91,16 +81,16 @@ storiesOf('FileManager', module).add('FileManager', () => {
   return (
     <BrowserRouter>
       <FileManager
-        submissionId={'MPManuscript:valid-manuscript-id-1'}
         can={capabilities}
-        attachments={attachments}
+        attachment={{
+          getAttachments: () => attachments,
+          upload,
+          replace,
+          changeDesignation,
+        }}
         modelMap={modelMap}
         saveModel={async () => action('save model')}
         enableDragAndDrop={true}
-        handleUpload={handleUpload}
-        handleDownload={handleDownload}
-        handleReplace={handleReplace}
-        handleChangeDesignation={handleChangeDesignation}
       />
     </BrowserRouter>
   )


### PR DESCRIPTION
- Define an interface for the file mutation callback, so this will be implemented in the dashboard to be used in both editor and dashboard inspector.

- Remove the `submissionId` props, as we use this value just for the mutation call, so will be passed to the mutation call from the dashboard.