### PR TITLE
File inspector cleanup (LEAN-1309) Move all logic of categorization attachments to the style-guide.

### DIFF
--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -17,13 +17,12 @@ import {
   Build,
   buildSupplementaryMaterial,
 } from '@manuscripts/manuscript-transform'
-import { Model, Supplement } from '@manuscripts/manuscripts-json-schema'
+import { Figure, Model, Supplement } from '@manuscripts/manuscripts-json-schema'
 import React, { createContext, useCallback, useReducer } from 'react'
 import ReactTooltip from 'react-tooltip'
 
 import { useFiles } from '../../index'
 import { Capabilities } from '../../lib/capabilities'
-import { AlertMessage, AlertMessageType } from '../AlertMessage'
 import {
   InspectorTab,
   InspectorTabList,
@@ -181,6 +180,8 @@ export const FileManager: React.FC<{
     [modelMap, saveModel]
   )
 
+  const attachments = getAttachments()
+
   const { otherFiles, supplementFiles, inlineFiles } = useFiles(
     modelMap,
     attachments
@@ -192,6 +193,8 @@ export const FileManager: React.FC<{
     const isSupplementOrOtherFilesTab =
       fileSection === FileSectionType.Supplements ||
       fileSection === FileSectionType.OtherFile
+    const isOtherFilesTab = fileSection === FileSectionType.OtherFile
+
     const itemsData =
       (fileSection === FileSectionType.Supplements && supplementFiles) ||
       otherFiles

--- a/src/components/FileManager/FileManager.tsx
+++ b/src/components/FileManager/FileManager.tsx
@@ -18,11 +18,11 @@ import {
   buildSupplementaryMaterial,
 } from '@manuscripts/manuscript-transform'
 import { Model, Supplement } from '@manuscripts/manuscripts-json-schema'
-import React, { createContext, useCallback, useMemo, useReducer } from 'react'
+import React, { createContext, useCallback, useReducer } from 'react'
 import ReactTooltip from 'react-tooltip'
 
+import { useFiles } from '../../index'
 import { Capabilities } from '../../lib/capabilities'
-import getInlineFiles, { getSupplementFiles } from '../../lib/inlineFiles'
 import { AlertMessage, AlertMessageType } from '../AlertMessage'
 import {
   InspectorTab,
@@ -45,7 +45,6 @@ import { InlineFilesSection } from './InlineFilesSection'
 import { TooltipDiv } from './TooltipDiv'
 import {
   Designation,
-  designationWithFileSectionsMap,
   FileSectionType,
   generateAttachmentsTitles,
   namesWithDesignationMap,
@@ -183,31 +182,10 @@ export const FileManager: React.FC<{
     [handleDownload]
   )
 
-  const inlineFiles = useMemo(
-    () => getInlineFiles(modelMap, attachments),
-    // eslint-disable-next-line
-    [modelMap.values(), attachments]
+  const { otherFiles, supplementFiles, inlineFiles } = useFiles(
+    modelMap,
+    attachments
   )
-
-  const supplementFiles = useMemo(
-    () => getSupplementFiles(modelMap, attachments),
-    // eslint-disable-next-line
-  [attachments, modelMap.size])
-
-  /**
-   * This Set of AttachmentsIds for both inlineFiles and supplement
-   * that will not be shown in other files
-   */
-  const excludedAttachmentsIds = useMemo(() => {
-    const attachmentsIDs = new Set<string>()
-    inlineFiles.map(({ attachments }) => {
-      if (attachments) {
-        attachments.map((attachment) => attachmentsIDs.add(attachment.id))
-      }
-    })
-    supplementFiles.map(({ id }) => attachmentsIDs.add(id))
-    return attachmentsIDs
-  }, [inlineFiles, supplementFiles])
 
   const getFileSectionExternalFile = (
     fileSection: FileSectionType
@@ -215,16 +193,9 @@ export const FileManager: React.FC<{
     const isSupplementOrOtherFilesTab =
       fileSection === FileSectionType.Supplements ||
       fileSection === FileSectionType.OtherFile
-    // Here we are filtering the external files to extract the other-files based on the designation.
     const itemsData =
       (fileSection === FileSectionType.Supplements && supplementFiles) ||
-      attachments.filter((element) => {
-        const designation: Designation | undefined =
-          namesWithDesignationMap.get(element.type.label)
-        return (
-          designation !== undefined && !excludedAttachmentsIds.has(element.id)
-        )
-      })
+      otherFiles
 
     // Generating a title for the external files and sorting the external files based on the generated title
     const itemsDataWithTitle = generateAttachmentsTitles(itemsData, fileSection)

--- a/src/hooks/use-deep-compare.ts
+++ b/src/hooks/use-deep-compare.ts
@@ -1,0 +1,34 @@
+/*!
+ * © 2022 Atypon Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isEqual } from 'lodash'
+import { useCallback, useMemo, useRef } from 'react'
+
+const useDeepCompare = <D>(deps: D) => {
+  const ref = useRef(deps)
+
+  if (!isEqual(deps, ref.current)) {
+    ref.current = deps
+  }
+
+  return ref.current
+}
+
+export const useDeepCompareMemo = <T, D>(callback: () => T, deps: D) =>
+  useMemo(callback, [useDeepCompare(deps), callback])
+
+export const useDeepCompareCallback = <T, D>(callback: () => T, deps: D) =>
+  useCallback(callback, [useDeepCompare(deps), callback])

--- a/src/hooks/use-files.ts
+++ b/src/hooks/use-files.ts
@@ -42,7 +42,7 @@ const getSupplementFiles = (
 
   return attachments.filter((attachment) => {
     if (supplements.has(attachment.id) && filePredicate) {
-      return filePredicate && filePredicate(attachment.name)
+      return filePredicate(attachment.name)
     } else {
       return supplements.has(attachment.id)
     }

--- a/src/hooks/use-files.ts
+++ b/src/hooks/use-files.ts
@@ -1,0 +1,102 @@
+/*!
+ * © 2022 Atypon Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getModelsByType } from '@manuscripts/manuscript-transform'
+import {
+  Model,
+  ObjectTypes,
+  Supplement,
+} from '@manuscripts/manuscripts-json-schema'
+
+import { SubmissionAttachment } from '../components/FileManager/FileSectionItem/FileSectionItem'
+import getInlineFiles, { InlineFile } from '../lib/inlineFiles'
+import { useDeepCompareMemo } from './use-deep-compare'
+
+type FilePredicate = (fileName: string) => boolean
+
+/**
+ * return attachments that are in the modelMap as MPSupplement
+ */
+const getSupplementFiles = (
+  modelMap: Map<string, Model>,
+  attachments: SubmissionAttachment[],
+  filePredicate?: FilePredicate
+) => {
+  const supplements = new Map(
+    getModelsByType<Supplement>(modelMap, ObjectTypes.Supplement).map(
+      (supplement) => [supplement.href?.replace('attachment:', ''), supplement]
+    )
+  )
+
+  return attachments.filter((attachment) => {
+    if (supplements.has(attachment.id) && filePredicate) {
+      return filePredicate && filePredicate(attachment.name)
+    } else {
+      return supplements.has(attachment.id)
+    }
+  })
+}
+
+/**
+ * return files that are not inlineFiles or SupplementFiles
+ */
+const getOtherFiles = (
+  inlineFiles: InlineFile[],
+  supplementFiles: SubmissionAttachment[],
+  attachments: SubmissionAttachment[],
+  filePredicate?: FilePredicate
+) => {
+  const inlineFilesAttachmentIds = inlineFiles
+    .map(({ attachments }) => attachments?.map(({ id }) => ({ id })) || [])
+    .flat()
+
+  const excludedAttachmentsIds = new Set(
+    [...inlineFilesAttachmentIds, ...supplementFiles].map(({ id }) => id)
+  )
+
+  return attachments.filter(({ id, name }) => {
+    if (!excludedAttachmentsIds.has(id) && filePredicate) {
+      return filePredicate(name)
+    } else {
+      return !excludedAttachmentsIds.has(id)
+    }
+  })
+}
+
+export default (
+  modelMap: Map<string, Model>,
+  attachments: SubmissionAttachment[],
+  filePredicate?: FilePredicate
+) =>
+  useDeepCompareMemo(() => {
+    const inlineFiles = getInlineFiles(modelMap, attachments)
+    const supplementFiles = getSupplementFiles(
+      modelMap,
+      attachments,
+      filePredicate
+    )
+    const otherFiles = getOtherFiles(
+      inlineFiles,
+      supplementFiles,
+      attachments,
+      filePredicate
+    )
+
+    return {
+      otherFiles,
+      supplementFiles,
+      inlineFiles,
+    }
+  }, [...Array.from(modelMap.values()), ...attachments])

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,11 +46,15 @@ export * from './components/Tip'
 export * from './components/icons'
 export * from './components/Inspector'
 export * from './components/InspectorSection'
-export { default as inlineFiles, getSupplementFiles } from './lib/inlineFiles'
 export { default as PdfPreview } from './components/PdfPreview'
 export * from './components/SubmissionInspector'
 export * from './components/Dropdown'
 export * from './hooks/use-dropdown'
+export { default as useFiles } from './hooks/use-files'
+export {
+  useDeepCompareMemo,
+  useDeepCompareCallback,
+} from './hooks/use-deep-compare'
 export * from './lib/authors'
 export * from './lib/capabilities'
 export { default as errorsDecoder } from './lib/lw-errors-decoder'


### PR DESCRIPTION
As we use `otherFiles` & `supplementFiles` in the editor body, we need to keep the logic of getting them in one place, which will be in the style-guide. so in the editor will just use the `use-files` hook.

and another thing I was adding dependency array of the useMemo like this:
> [modelMap.values(), attachments]

to always keep the inline-files section updated with the `modelMap`, but this will lead to calling the hook `useMemo` repeatedly so I created the `use-deep-compare` hook to recall `useMemo` hook in case the dependency is not equal, and for equality will use lodash. 