### PR TITLE
LEAN-3502: LW-FY24-Q4-S5: The References context menu is still fixed …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/style-guide",
   "description": "Shared components for Manuscripts applications",
-  "version": "1.12.12",
+  "version": "1.12.13",
   "repository": "github:Atypon-OpenSource/manuscripts-style-guide",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/components/EditorHeader/EditorHeader.tsx
+++ b/src/components/EditorHeader/EditorHeader.tsx
@@ -289,6 +289,7 @@ export const PrimaryButtonSmall = styled(PrimaryButton)`
 
 const Wrapper = styled.div`
   display: flex;
+  z-index: 6;
   padding: ${(props) => props.theme.grid.unit * 3}px
     ${(props) => props.theme.grid.unit * 8}px;
   width: 100%;
@@ -296,6 +297,7 @@ const Wrapper = styled.div`
   align-items: center;
   border-bottom: 1px solid #f2f2f2;
   font-size: 14px;
+  background: white;
 
   ${NavDropdownContainer} + ${NavDropdownContainer} {
     margin-left: ${(props) => props.theme.grid.unit * 2}px;


### PR DESCRIPTION
…and appears when clicking outside it

z-index is increased to hide scrolling popper behind the editor header...