### PR TITLE
LEAN-2960:LW-FY24- Q2-S5: File extension is not showing for the trunc

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -25,7 +25,7 @@ export const Tooltip = styled(ReactTooltip).attrs({
     font-size: 12px;
     line-height: 16px;
     letter-spacing: -0.2px;
-    max-width: 300px;
+    max-width: 100%;
     font-family: inherit;
     padding: 8px;
     border-radius: 3px;


### PR DESCRIPTION
Trimming the file name to show the file extension and Add a tooltip to display full file names without cropping, as recommended in comment [#2](https://jira.atypon.com/browse/LEAN-2960?focusedCommentId=6255294#comment-6255294). Once implemented, we'll seek approval from VIP after moving the changes to QA.