### PR TITLE
Decouple from the role approach to allow edit without tracking -  LEAN-4122

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/style-guide",
   "description": "Shared components for Manuscripts applications",
-  "version": "2.1.10",
+  "version": "2.1.11-LEAN-4122.0",
   "repository": "github:Atypon-OpenSource/manuscripts-style-guide",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/style-guide",
   "description": "Shared components for Manuscripts applications",
-  "version": "2.1.12",
+  "version": "2.1.13-LEAN-4122.0",
   "repository": "github:Atypon-OpenSource/manuscripts-style-guide",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manuscripts/style-guide",
   "description": "Shared components for Manuscripts applications",
-  "version": "2.1.13-LEAN-4122.0",
+  "version": "2.1.13",
   "repository": "github:Atypon-OpenSource/manuscripts-style-guide",
   "license": "Apache-2.0",
   "main": "dist/cjs",

--- a/src/lib/capabilities.tsx
+++ b/src/lib/capabilities.tsx
@@ -82,6 +82,7 @@ export const getCapabilities = (
 
   const isOwner = isMemberOf(project?.owners)
   const isEditor = isMemberOf(project?.editors)
+  const isWriter = isMemberOf(project?.writers)
   const isAnnotator = isMemberOf(project?.annotators)
   const isProofer = isMemberOf(project?.proofers)
   const isViewer = isMemberOf(project?.viewers) || isViewingMode
@@ -89,7 +90,7 @@ export const getCapabilities = (
   const allowed = (action: string) => !!actions?.includes(action)
 
   const canEditWithoutTracking = allowed(Actions.editWithoutTracking)
-  const isPrivileged = isOwner || isEditor || canEditWithoutTracking
+  const isPrivileged = isOwner || isEditor || isWriter || canEditWithoutTracking
   const canHandleAttachments =
     (isPrivileged || isAnnotator) && allowed(Actions.updateAttachment)
 

--- a/src/lib/capabilities.tsx
+++ b/src/lib/capabilities.tsx
@@ -90,9 +90,9 @@ export const getCapabilities = (
   const allowed = (action: string) => !!actions?.includes(action)
 
   const canEditWithoutTracking = allowed(Actions.editWithoutTracking)
-  const isPrivileged = isOwner || isEditor || isWriter || canEditWithoutTracking
-  const canHandleAttachments =
-    (isPrivileged || isAnnotator) && allowed(Actions.updateAttachment)
+  const isPrivileged = isOwner || isEditor || isWriter
+  const canEditFiles = (isPrivileged || isAnnotator) && !isViewingMode
+  const canUpdateAttachments = canEditFiles && allowed(Actions.updateAttachment)
 
   return {
     /* track changes */
@@ -109,11 +109,11 @@ export const getCapabilities = (
 
     /* file handling */
     downloadFiles: true,
-    changeDesignation: canHandleAttachments,
-    moveFile: isPrivileged || isAnnotator,
-    replaceFile: canHandleAttachments,
-    uploadFile: canHandleAttachments,
-    detachFile: isPrivileged || isAnnotator,
+    changeDesignation: canUpdateAttachments,
+    moveFile: canEditFiles,
+    replaceFile: canUpdateAttachments,
+    uploadFile: canUpdateAttachments,
+    detachFile: canEditFiles,
     setMainManuscript: allowed(Actions.setMainManuscript),
 
     /* editor */

--- a/src/lib/capabilities.tsx
+++ b/src/lib/capabilities.tsx
@@ -17,26 +17,18 @@ import { Project, UserProfile } from '@manuscripts/json-schema'
 import React from 'react'
 
 export type Capabilities = {
-  /* suggestions */
+  /* track changes */
   handleSuggestion: boolean
+  editWithoutTracking: boolean
   rejectOwnSuggestion: boolean
-  createSuggestion: boolean
-  viewSuggestion: boolean
+
   /* comments */
-  seeEditorToolbar: boolean
-  seeReferencesButtons: boolean
   handleOwnComments: boolean
   resolveOwnComment: boolean
   handleOthersComments: boolean
   resolveOthersComment: boolean
   createComment: boolean
-  /* production notes */
-  viewNotes: boolean
-  createNotes: boolean
-  handleNotes: boolean // Approve rejecet owns and others
-  /* history */
-  viewHistory: boolean
-  restoreVersion: boolean
+
   /* file handling */
   downloadFiles: boolean
   changeDesignation: boolean
@@ -44,24 +36,15 @@ export type Capabilities = {
   replaceFile: boolean
   uploadFile: boolean
   detachFile: boolean
-  handleQualityReport: boolean
   setMainManuscript: boolean
-  /* dashboard actions */
-  // completeTask: boolean
-  rejectTask: boolean
-  acceptTask: boolean
-  resolveOnHoldTask: boolean
-  putOnHoldTask: boolean
-  changeDueDate: boolean
-  previewAccess: boolean
-  editWithoutTracking: boolean
-  accessEditor: boolean
+
+  /* editor */
   formatArticle: boolean
   editArticle: boolean
   editMetadata: boolean
-  shareProject: boolean
   editCitationsAndRefs: boolean
-  applySaveChanges: boolean
+  seeEditorToolbar: boolean
+  seeReferencesButtons: boolean
 }
 
 enum Actions {
@@ -70,6 +53,7 @@ enum Actions {
   updateDueDate = 'update-due-date',
   addNote = 'add-note',
   setMainManuscript = 'set-main-manuscript',
+  editWithoutTracking = 'edit-without-tracking',
 }
 
 export interface ProviderProps {
@@ -91,74 +75,53 @@ export const getCapabilities = (
   actions?: string[],
   isViewingMode?: boolean
 ): Capabilities => {
-  const isEditor = () =>
-    !!(profile && project?.editors?.includes(profile.userID))
-  const isOwner = () => !!(profile && project?.owners?.includes(profile.userID))
-  const isWriter = () =>
-    !!(profile && project?.writers?.includes(profile.userID))
-  const isAnnotator = () =>
-    !!(profile && project?.annotators?.includes(profile.userID))
-  const isProofer = () =>
-    !!(profile && project?.proofers?.includes(profile.userID))
-  const isViewer = () =>
-    !!(profile && project?.viewers?.includes(profile.userID)) || isViewingMode
-  const isProdEditor = () => role == 'pe'
+  const userID = profile?.userID
+
+  const isMemberOf = (group?: string[]) =>
+    group?.includes(userID ?? '') ?? false
+
+  const isOwner = isMemberOf(project?.owners)
+  const isEditor = isMemberOf(project?.editors)
+  const isAnnotator = isMemberOf(project?.annotators)
+  const isProofer = isMemberOf(project?.proofers)
+  const isViewer = isMemberOf(project?.viewers) || isViewingMode
+
   const allowed = (action: string) => !!actions?.includes(action)
 
+  const canEditWithoutTracking = allowed(Actions.editWithoutTracking)
+  const isPrivileged = isOwner || isEditor || canEditWithoutTracking
+  const canHandleAttachments =
+    (isPrivileged || isAnnotator) && allowed(Actions.updateAttachment)
+
   return {
-    /* suggestions */
-    handleSuggestion: isOwner() || isEditor() || isWriter(),
-    editWithoutTracking: isWriter(),
-    rejectOwnSuggestion: !isViewer(),
-    createSuggestion: !isViewer(),
-    viewSuggestion: true,
-    seeEditorToolbar: !isViewer(),
-    seeReferencesButtons: !isViewer(),
+    /* track changes */
+    handleSuggestion: isPrivileged,
+    editWithoutTracking: canEditWithoutTracking,
+    rejectOwnSuggestion: !isViewer,
+
     /* comments */
-    handleOwnComments: !isViewer(),
-    handleOthersComments: isOwner(),
-    resolveOwnComment: !isViewer(),
-    resolveOthersComment: !(isViewer() || isAnnotator() || isProofer()),
-    createComment: !isViewer(),
-    /* production notes */
-    viewNotes: true,
-    createNotes: !isViewer() && allowed(Actions.addNote),
-    handleNotes: isOwner() || isEditor() || isWriter() || isAnnotator(), // Approve rejecet owns and others
-    /* history */
-    viewHistory: false,
-    restoreVersion: isOwner() || isEditor() || isWriter(),
+    handleOwnComments: !isViewer,
+    handleOthersComments: isOwner,
+    resolveOwnComment: !isViewer,
+    resolveOthersComment: isOwner || isEditor,
+    createComment: !isViewer,
+
     /* file handling */
     downloadFiles: true,
-    changeDesignation:
-      (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
-      allowed(Actions.updateAttachment),
-    moveFile: isOwner() || isEditor() || isWriter() || isAnnotator(),
-    replaceFile:
-      (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
-      allowed(Actions.updateAttachment),
-    uploadFile:
-      (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
-      allowed(Actions.updateAttachment),
-    detachFile: isOwner() || isEditor() || isWriter() || isAnnotator(),
-    handleQualityReport: isOwner() || isEditor() || isWriter(),
+    changeDesignation: canHandleAttachments,
+    moveFile: isPrivileged || isAnnotator,
+    replaceFile: canHandleAttachments,
+    uploadFile: canHandleAttachments,
+    detachFile: isPrivileged || isAnnotator,
     setMainManuscript: allowed(Actions.setMainManuscript),
-    /* dashboard actions */
-    // completeTask: !isViewer() && allowed(Actions.proceed),
-    rejectTask: isProdEditor(),
-    acceptTask: isProdEditor(),
-    resolveOnHoldTask: isProdEditor(),
-    putOnHoldTask: isProdEditor(),
-    changeDueDate: isProdEditor() && allowed(Actions.updateDueDate),
-    previewAccess: true,
-    accessEditor: true,
-    /* menu */
-    formatArticle: !isViewer(),
+
     /* editor */
-    editArticle: !isViewer(),
-    editMetadata: !(isViewer() || isProofer()) || isAnnotator(),
-    editCitationsAndRefs: !(isViewer() || isProofer()),
-    shareProject: isOwner(),
-    applySaveChanges: !(isAnnotator() || isProofer()),
+    editArticle: !isViewer,
+    formatArticle: !isViewer,
+    editMetadata: !(isViewer || isProofer),
+    editCitationsAndRefs: !(isViewer || isProofer),
+    seeEditorToolbar: !isViewer,
+    seeReferencesButtons: !isViewer,
   }
 }
 


### PR DESCRIPTION
- Start depending on permitted actions to see if a user `canEditWithoutTracking`.
- Some cleanup work.