### PR TITLE
Block replace, upload& detach when in viewing mode - LEAN-4511

### DIFF
--- a/src/lib/capabilities.tsx
+++ b/src/lib/capabilities.tsx
@@ -135,11 +135,15 @@ export const getCapabilities = (
     moveFile: isOwner() || isEditor() || isWriter() || isAnnotator(),
     replaceFile:
       (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
-      allowed(Actions.updateAttachment),
+      allowed(Actions.updateAttachment) &&
+      !isViewingMode,
     uploadFile:
       (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
-      allowed(Actions.updateAttachment),
-    detachFile: isOwner() || isEditor() || isWriter() || isAnnotator(),
+      allowed(Actions.updateAttachment) &&
+      !isViewingMode,
+    detachFile:
+      (isOwner() || isEditor() || isWriter() || isAnnotator()) &&
+      !isViewingMode,
     handleQualityReport: isOwner() || isEditor() || isWriter(),
     setMainManuscript: allowed(Actions.setMainManuscript),
     /* dashboard actions */


### PR DESCRIPTION
I'm already working on cleaning up `getCapabilities` in https://github.com/Atypon-OpenSource/manuscripts-style-guide/pull/268, but this is a quick fix needed for LEAN-4511.