### PR TITLE
Citation modal redesign (LEAN-5688)

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -424,7 +424,7 @@ export const ButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-
+  gap: 4px;
   button:not(:first-child) {
     margin-left: ${(props) => props.theme.grid.unit}px;
   }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -424,10 +424,7 @@ export const ButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  gap: 4px;
-  button:not(:first-child) {
-    margin-left: ${(props) => props.theme.grid.unit}px;
-  }
+  gap: ${(props) => props.theme.grid.unit * 2}px;
 `
 
 export const IconButtonGroup = styled.div<{ size?: number }>`


### PR DESCRIPTION
This is a general fix to the ButtonGroup to resolve the general issue when button get focused with an outline border overlay to the adjacent element, like these examples: 
<img width="333" height="111" alt="Screenshot from 2026-06-24 13-27-33" src="https://github.com/user-attachments/assets/e6056250-db37-4ee3-9fd0-b7480c24f60f" />
<img width="333" height="111" alt="Screenshot from 2026-06-24 13-27-57" src="https://github.com/user-attachments/assets/48eec56b-34bd-424e-b586-5b9177bb2202" />
